### PR TITLE
Add already assigned class filter in exam

### DIFF
--- a/app/ExamForClass.php
+++ b/app/ExamForClass.php
@@ -11,4 +11,8 @@ class ExamForClass extends Model
     public function classes(){
         return $this->hasMany('App\Myclass');
     }
+
+    public function exam(){
+        return $this->belongsTo('App\Exam');
+    }
 }

--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -40,7 +40,8 @@ class ExamController extends Controller
     public function create()
     {
         $classes = $this->examService->getClassesBySchoolId();
-        return view('exams.add',compact('classes'));
+        $already_assigned_classes = $this->examService->getAlreadyAssignedClasses();
+        return view('exams.add',compact('classes','already_assigned_classes'));
     }
 
     /**

--- a/app/Services/Exam/ExamService.php
+++ b/app/Services/Exam/ExamService.php
@@ -34,6 +34,16 @@ class ExamService {
         return Myclass::where('school_id',auth()->user()->school->id)->get();
     }
 
+    public function getAlreadyAssignedClasses(){
+        $classes = $this->getClassesBySchoolId()
+                        ->pluck('id')
+                        ->toArray();
+        return ExamForClass::with('exam')
+                            ->where('active', 1)
+                            ->whereIn('class_id', $classes)
+                            ->get();
+    }
+
     public function createExam(){
         $exam = new Exam;
         $exam->exam_name = $this->request->exam_name;

--- a/resources/views/components/add-exam-form.blade.php
+++ b/resources/views/components/add-exam-form.blade.php
@@ -61,11 +61,24 @@
 
         <div class="col-md-6">
             @foreach ($classes as $class)
+                @if(in_array($class->id, $assigned_classes->pluck('class_id')->toArray()))
+                    <div class="checkbox">
+                        {{$class->class_number}} already assigned to Exam <b>
+                        @foreach($assigned_classes as $assigned_class)
+                            @if($assigned_class->class_id == $class->id)
+                                {{$assigned_class->exam->exam_name}}
+                                @break
+                            @endif
+                        @endforeach
+                        </b>
+                    </div>
+                @else
                 <div class="checkbox">
                     <label>
                         <input type="checkbox" name="classes[]" value="{{$class->id}}"> {{$class->class_number}}
                     </label>
                 </div>
+                @endif
             @endforeach
 
             @if ($errors->has('classes'))

--- a/resources/views/exams/add.blade.php
+++ b/resources/views/exams/add.blade.php
@@ -17,7 +17,7 @@
                         </div>
                     @endif
 
-                    @component('components.add-exam-form',['classes'=>$classes])
+                    @component('components.add-exam-form',['classes'=>$classes,'assigned_classes'=>$already_assigned_classes,])
                     @endcomponent
                 </div>
             </div>

--- a/tests/Feature/Library/IssuedBookModuleTest.php
+++ b/tests/Feature/Library/IssuedBookModuleTest.php
@@ -28,5 +28,6 @@ class IssuedBookModuleTest extends TestCase
         ]);
         $this->followingRedirects()->post('library/issue-books', $request->toArray())
             ->assertStatus(200);
+        $this->assertEquals(Issuedbook::count(),count((array)$request->book_id));
     }
 }


### PR DESCRIPTION
Now admin can see if any class is already assigned to any active exam and if true then that class can not be assigned to a new exam until that exam mark as completed.