### PR TITLE
feat: disable laravel-pagespeed when testing

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="LARAVEL_PAGE_SPEED_ENABLE" value="false"/>
     </php>
 </phpunit>


### PR DESCRIPTION
I kept getting failing tests when I ran `phpunit`. This fixes it, by disabling laravel-page-speed during testing.