### PR TITLE
feat: allow master account to edit a school

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ npm-debug.log
 yarn-error.log
 .env
 .php_cs.cache
+.rnd

--- a/app/Http/Controllers/SchoolController.php
+++ b/app/Http/Controllers/SchoolController.php
@@ -84,9 +84,19 @@ class SchoolController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function edit($id)
+    public function edit(Request $request, $school_id)
     {
-        //
+      $school = School::find($school_id);
+      if (!$school) {
+        abort(404);
+      }
+      if ($request->isMethod('post')) {
+        $school->name = $request->name;
+        $school->about = $request->about;
+        $school->theme = $request->school_theme;
+        $school->save();
+      }
+      return view('school.edit-school',compact('school'));
     }
 
     public function addDepartment(Request $request){

--- a/resources/views/layouts/master/theme-form.blade.php
+++ b/resources/views/layouts/master/theme-form.blade.php
@@ -2,25 +2,7 @@
   {{csrf_field()}}
   <input type="hidden" name="s" value="{{$school->id}}">
   <div class="form-group">
-      <select class="form-control input-sm" id="schoolTheme{{$school->id}}" name="school_theme">
-        <option value="{{$school->theme}}" selected>{{$school->theme}}</option>
-        <option value="cosmo">cosmo</option>
-        <option value="cyborg">cyborg</option>
-        <option value="darkly">darkly</option>
-        <option value="flatly">flatly</option>
-        <option value="journal">journal</option>
-        <option value="lumen">lumen</option>
-        <option value="paper">paper</option>
-        <option value="readable">readable</option>
-        <option value="sandstone">sandstone</option>
-        <option value="slate">slate</option>
-        <option value="simplex">simplex</option>
-        <option value="solar">solar</option>
-        <option value="spacelab">spacelab</option>
-        <option value="superhero">superhero</option>
-        <option value="united">united</option>
-        <option value="yeti">yeti</option>
-      </select>
+      @include('layouts.theme-select')
       <button type="submit" class="btn btn-success btn-sm">Submit</button>
   </div>
 </form>

--- a/resources/views/layouts/master/theme-select.blade.php
+++ b/resources/views/layouts/master/theme-select.blade.php
@@ -1,0 +1,27 @@
+<select class="form-control input-sm" id="schoolTheme{{$school->id}}" name="school_theme">
+    <option value="cosmo">cosmo</option>
+    <option value="cyborg">cyborg</option>
+    <option value="darkly">darkly</option>
+    <option value="flatly">flatly</option>
+    <option value="journal">journal</option>
+    <option value="lumen">lumen</option>
+    <option value="paper">paper</option>
+    <option value="readable">readable</option>
+    <option value="sandstone">sandstone</option>
+    <option value="slate">slate</option>
+    <option value="simplex">simplex</option>
+    <option value="solar">solar</option>
+    <option value="spacelab">spacelab</option>
+    <option value="superhero">superhero</option>
+    <option value="united">united</option>
+    <option value="yeti">yeti</option>
+</select>
+
+<script>
+    (function () {
+        var schoolSelectElement = document.querySelector('#schoolTheme{{$school->id}}');
+        if (schoolSelectElement) {
+            schoolSelectElement.value = "{{$school->theme}}"
+        }
+    })()
+</script>

--- a/resources/views/school/create-school.blade.php
+++ b/resources/views/school/create-school.blade.php
@@ -49,6 +49,7 @@
                         <th scope="col">Teachers</th> --}}
                       @endif
                       @if(\Auth::user()->role == 'master')
+                        <th scope="col">Edit</th>
                         <th scope="col">+Admin</th>
                         <th scope="col">View Admins</th>
                       @endif
@@ -115,6 +116,9 @@
                       </td> --}}
                       @endif
                       @if(\Auth::user()->role == 'master')
+                        <td>
+                          <a class="btn btn-success btn-sm" role="button" href="{{url('school/'.$school->id)}}"><small>Edit School</small></a>
+                        </td>
                         <td>
                           <a class="btn btn-danger btn-sm" role="button" href="{{url('register/admin/'.$school->id.'/'.$school->code)}}"><small>+ Create Admin</small></a>
                         </td>

--- a/resources/views/school/edit-school.blade.php
+++ b/resources/views/school/edit-school.blade.php
@@ -1,0 +1,88 @@
+@extends('layouts.app')
+
+@section('title', 'Edit School')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+      @if(\Auth::user()->role != 'master')
+        <div class="col-md-2" id="side-navbar">
+          @include('layouts.leftside-menubar')
+        </div>
+      @endif
+        <div class="col-md-{{ (\Auth::user()->role == 'master')? 12 : 10 }}" id="main-container">
+            @if (session('status'))
+              <div class="alert alert-success">
+                {{ session('status') }}
+              </div>
+            @endif
+            @if ($errors->any())
+                <div class="alert alert-danger">
+                    <ul>
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+            <div class="panel panel-default">
+              <div class="panel-body table-responsive">
+                @if(\Auth::user()->role == 'master')
+                    <h2>Edit {{$school->name}}</h2>
+
+                    <form class="form-horizontal" action="{{url('school/' . $school->id)}}" method="post">
+                        {{ csrf_field() }}
+                        <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
+                            <label for="name" class="col-md-4 control-label">School Name</label>
+  
+                            <div class="col-md-6">
+                                <input id="name" type="text" class="form-control" name="name" value="{{ $school->name }}" placeholder="Form Field Name" required>
+  
+                                @if ($errors->has('name'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('name') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+                        <div class="form-group{{ $errors->has('about') ? ' has-error' : '' }}">
+                            <label for="about" class="col-md-4 control-label">About School</label>
+  
+                            <div class="col-md-6">
+                                <textarea id="about" type="text" class="form-control" name="about" 
+                                    placeholder="Form Field Name" required>{{ $school->about }}</textarea>
+  
+                                @if ($errors->has('about'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('about') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+                        <div class="form-group{{ $errors->has('school_theme') ? ' has-error' : '' }}">
+                            <label for="school_theme" class="col-md-4 control-label">Choose Theme</label>
+  
+                            <div class="col-md-6">
+                                @include('layouts.master.theme-select')
+  
+                                @if ($errors->has('school_theme'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('school_theme') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+                        
+                        <div class="form-group">
+                          <div class="col-sm-offset-4 col-sm-8">
+                            <button type="submit" class="btn btn-danger">Save</button>
+                          </div>
+                        </div>
+                    </form>
+                @endif
+              </div>
+          </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,6 +189,8 @@ Route::middleware(['auth','master'])->group(function (){
   Route::get('master/deactivate-admin/{id}','UserController@deactivateAdmin');
   Route::post('create-school', 'SchoolController@store');
   Route::get('school/admin-list/{school_id}','SchoolController@show');
+  Route::get('school/{school_id}','SchoolController@edit');
+  Route::post('school/{school_id}','SchoolController@edit');
 });
 
 Route::middleware(['auth','admin'])->group(function (){

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,8 +189,6 @@ Route::middleware(['auth','master'])->group(function (){
   Route::get('master/deactivate-admin/{id}','UserController@deactivateAdmin');
   Route::post('create-school', 'SchoolController@store');
   Route::get('school/admin-list/{school_id}','SchoolController@show');
-  Route::get('school/{school_id}','SchoolController@edit');
-  Route::post('school/{school_id}','SchoolController@edit');
 });
 
 Route::middleware(['auth','admin'])->group(function (){
@@ -233,6 +231,10 @@ Route::middleware(['auth','admin'])->group(function (){
   Route::post('edit/course/{id}','CourseController@updateNameAndTime');
 });
 
+Route::middleware(['auth', 'master'])->group(function () {
+  Route::get('school/{school_id}','SchoolController@edit');
+  Route::post('school/{school_id}','SchoolController@edit');
+});
 
 
 //use PDF;

--- a/tests/Feature/Manage/SchoolModuleTest.php
+++ b/tests/Feature/Manage/SchoolModuleTest.php
@@ -33,6 +33,15 @@ class SchoolModuleTest extends TestCase
             ->assertViewHas('schools');
     }
     /** @test */
+    public function it_shows_edit_school() {
+        $master = factory(User::class)->states('master')->create();
+        $this->actingAs($master);
+        $this->followingRedirects()
+            ->get('school/1')
+            ->assertStatus(200)
+            ->assertViewHas('school');
+    }
+    /** @test */
     public function it_shows_the_teachers_list() {
         $this->get('create-school')
             ->assertStatus(200)


### PR DESCRIPTION
I realized there was no way to change a school's basic info like it's `name`, and `about`.

This PR gives the master account the ability to edit a school's basic info.

> I considered letting the school admins have this functionality, but there can be multiple admins, so only the `master` account should be able to do this.