### PR TITLE
Added Distinct clause when retrieving Grade System Names

### DIFF
--- a/app/Services/Grade/GradeService.php
+++ b/app/Services/Grade/GradeService.php
@@ -64,19 +64,16 @@ class GradeService {
   }
 
   public function getGradeSystemBySchoolId($grades){
-    $grade_system_name = isset($grades[0]->course->grade_system_name) ? $grades[0]->course->grade_system_name : false;
-    return ($grade_system_name)?Gradesystem::where('school_id', auth()->user()->school_id)
-                        ->where('grade_system_name', $grade_system_name)
-                        //->groupBy('grade_system_name')
-                        ->get() : [];
-    
+    return Gradesystem::select('grade_system_name')
+    ->where('school_id', auth()->user()->school_id)
+    ->distinct()
+    ->get();
   }
 
   public function getGradeSystemByname($grade_system_name){
     return Gradesystem::where('school_id', auth()->user()->school_id)
                         ->where('grade_system_name', $grade_system_name)
                         ->get();
-    
   }
 
   public function gradeIndexView($view){


### PR DESCRIPTION
On my tests I wasn't getting any value populated on the Grade System dropdown on course-grade.blade.php page when assigning grades.

I did the fix as my understanding of how it should work. Would  you kindly validate if this fix is correct?