### PR TITLE
Fix on Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.2-fpm-stretch
 
 # Copy composer.lock and composer.json
 COPY composer.lock composer.json /var/www/


### PR DESCRIPTION
php:7.2-fpm changed to Debian Buster and it broke lots of things.
Just a matter of changing the base image back to Stretch.