### PR TITLE
Test Coverage for Login User Authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     restart: unless-stopped
     tty: true
     ports:
-      - "3306:3306"
+      - "3307:3306"
     environment:
       MYSQL_DATABASE: unifiedtransform
       MYSQL_ROOT_PASSWORD: your_mysql_root_password

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,7 +22,7 @@
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="DB_CONNECTION" value="sqlite"/>
-        server name="DB_DATABASE" value=":memory:"/>
+        <server name="DB_DATABASE" value=":memory:"/>
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+use App\Models\User;
+
+class AuthTest extends TestCase
+{
+    use RefreshDatabase;
+    /**
+     * @test
+     *
+     * Test whether user can view a login form if they visit a login route
+     */
+    public function user_can_view_a_login_form()
+    {
+        $response = $this->get('/login');
+        $response->assertSuccessful();
+        $response->assertViewIs('auth.login');
+    }
+
+    /**
+     * @test
+     *
+     * Test if user cannot view a login page when they are authenticated(logged In)
+     */
+    public function user_cannot_view_login_form_when_authenticated()
+    {
+        $user = User::factory()->make();
+        $response = $this->actingAs($user)->get('/login');
+        $response->assertRedirect('/home');
+
+    }
+
+    /**
+     * @test
+     *
+     * Test if user can successfully log in with correct credentials
+     */
+    public function user_can_login_successfully_with_correct_credentials()
+    {
+        $password = '::password::';
+        $user = User::factory()->create([
+            'password' => Hash::make($password),
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => $password,
+        ]);
+
+        $response->assertRedirect('/home');
+        $this->assertAuthenticatedAs($user);
+    }
+
+
+    /**
+     * @test
+     *
+     * Test if user cannot log in with incorrect password.
+     *
+     */
+    public function user_cannot_login_with_incorrect_password()
+    {
+        $password = '::password::';
+        $user = User::factory()->create([
+            'password' => Hash::make($password),
+        ]);
+
+        $response = $this->from('/login')->post('/login', [
+            'email' => $user->email,
+            'password' => '::incorrect-password::',
+        ]);
+
+        $response->assertRedirect('/login');
+        $response->assertSessionHasErrors('email');
+//        $this->assertAuthenticatedAs($user);
+    }
+}
+


### PR DESCRIPTION
Hello,

I decided to write tests for Authentication specifically login because i realized there was no test coverage at all in v2.
I don't know what format i had use but i tried as much as possible to folloe best practices.

All you have to do is run: `php artisan test` after successful setup

For now, the tests cover 
- If a user can view login page
- If a user cannot view login page after authentication
- If a user can login successfully with correct credentials
- if a user cannot login with incorrect password

as shown below
![testut](https://user-images.githubusercontent.com/41926048/161799305-3e2eaaef-8db7-445b-9d07-c5ab28d1b80e.png)

Thank you
